### PR TITLE
Fix for Issue #55 - Adding async/await pattern for most i/o calls

### DIFF
--- a/Balanced/Account.cs
+++ b/Balanced/Account.cs
@@ -48,9 +48,19 @@ namespace Balanced
             return Resource.Fetch<Account>(href);
         }
 
+        public static Task<Account> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Account>(href);
+        }
+
         public void Save()
         {
             this.Save<Account>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Account>();
         }
 
         public void Reload()
@@ -58,19 +68,23 @@ namespace Balanced
             this.Reload<Account>();
         }
 
-
-        public override Credit Credit(Dictionary<string, object> payload)
+        public Task ReloadAsync()
         {
-            return credits.Create(payload);
+            return this.ReloadAsync<Account>();
         }
 
-        public override Debit Debit(Dictionary<string, object> payload)
+        public override Task<Credit> CreditAsync(Dictionary<string, object> payload)
+        {
+            return credits.CreateAsync(payload);
+        }
+
+        public override Task<Debit> DebitAsync(Dictionary<string, object> payload)
         {
             if (this.can_debit == false)
             {
                 throw new Exceptions.FundingInstrumentNotDebitable();
             }
-            return debits.Create(payload);
+            return debits.CreateAsync(payload);
         }
 
         public Settlement Settle(Dictionary<string, object> payload)

--- a/Balanced/ApiKey.cs
+++ b/Balanced/ApiKey.cs
@@ -26,15 +26,31 @@ namespace Balanced
             return Resource.Fetch<ApiKey>(href);
         }
 
+        public static Task<ApiKey> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<ApiKey>(href);
+        }
+
         public void Save()
         {
             Balanced.configure(null);
             this.Save<ApiKey>();
         }
 
+        public Task SaveAsync()
+        {
+            Balanced.configure(null);
+            return this.SaveAsync<ApiKey>();
+        }
+
         public void SaveToMarketplace()
         {
             this.Save<ApiKey>();
+        }
+
+        public Task SaveToMarketplaceAsync()
+        {
+            return this.SaveAsync<ApiKey>();
         }
 
         public class Collection : ResourceCollection<ApiKey>

--- a/Balanced/BankAccount.cs
+++ b/Balanced/BankAccount.cs
@@ -53,14 +53,29 @@ namespace Balanced
             return Resource.Fetch<BankAccount>(href);
         }
 
+        public static Task<BankAccount> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<BankAccount>(href);
+        }
+
         public void Save()
         {
             this.Save<BankAccount>();
         }
 
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<BankAccount>();
+        }
+
         public void Reload()
         {
             this.Reload<BankAccount>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<BankAccount>();
         }
 
         public void AssociateToCustomer(Customer customer)
@@ -70,25 +85,43 @@ namespace Balanced
 
         public void AssociateToCustomer(string href)
         {
+            AssociateToCustomerAsync(href).GetAwaiter().GetResult();
+        }
+
+        public Task AssociateToCustomerAsync(Customer customer)
+        {
+            return this.AssociateToCustomerAsync(customer.href);
+        }
+
+        public async Task AssociateToCustomerAsync(string href)
+        {
             if (href != null)
             {
                 links.Add("customer", href);
-                this.Save();
+                await this.SaveAsync();
             }
         }
 
-        public override Credit Credit(Dictionary<string, object> payload)
+        public override Task<Credit> CreditAsync(Dictionary<string, object> payload)
         {
-            return credits.Create(payload);
+            return credits.CreateAsync(payload);
         }
 
-        public override Debit Debit(Dictionary<string, object> payload)
+        public override Task<Debit> DebitAsync(Dictionary<string, object> payload)
         {
-            return debits.Create(payload);
+            return debits.CreateAsync(payload);
         }
 
-        public BankAccountVerification Verify() { return verifications.Create(); }
-        
+        public BankAccountVerification Verify()
+        {
+            return verifications.Create();
+        }
+
+        public Task<BankAccountVerification> VerifyAsync()
+        {
+            return verifications.CreateAsync();
+        }
+
         public class Collection : ResourceCollection<BankAccount>
         {
             public Collection() : base(resource_href) { }

--- a/Balanced/BankAccountVerification.cs
+++ b/Balanced/BankAccountVerification.cs
@@ -39,9 +39,19 @@ namespace Balanced
             return Resource.Fetch<BankAccountVerification>(href);
         }
 
+        public static Task<BankAccountVerification> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<BankAccountVerification>(href);
+        }
+
         public void Save()
         {
             this.Save<BankAccountVerification>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<BankAccountVerification>();
         }
 
         public void Reload()
@@ -49,13 +59,25 @@ namespace Balanced
             this.Reload<BankAccountVerification>();
         }
 
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<BankAccountVerification>();
+        }
+
         public void Confirm(int amount_1, int amount_2)
         {
-            Dictionary<string, int> payload = new Dictionary<string, int>();
-            payload.Add("amount_1", amount_1);
-            payload.Add("amount_2", amount_2);
-            Client.Put<BankAccountVerification>(href, Resource.Serialize(payload));
-            Reload();
+            ConfirmAsync(amount_1, amount_2).GetAwaiter().GetResult();
+        }
+
+        public async Task ConfirmAsync(int amount_1, int amount_2)
+        {
+            var payload = new Dictionary<string, int>
+            {
+                {"amount_1", amount_1}, 
+                {"amount_2", amount_2}
+            };
+            await Client.PutAsync<BankAccountVerification>(href, Resource.Serialize(payload));
+            await ReloadAsync();
         }
 
         public class Collection : ResourceCollection<BankAccountVerification>

--- a/Balanced/Callback.cs
+++ b/Balanced/Callback.cs
@@ -35,9 +35,19 @@ namespace Balanced
             return Resource.Fetch<Callback>(href);
         }
 
+        public static Task<Callback> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Callback>(href);
+        }
+
         public void Save()
         {
             this.Save<Callback>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Callback>();
         }
 
         public class Collection : ResourceCollection<Callback>

--- a/Balanced/Card.cs
+++ b/Balanced/Card.cs
@@ -71,14 +71,29 @@ namespace Balanced
             return Resource.Fetch<Card>(href);
         }
 
+        public static Task<Card> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Card>(href);
+        }
+
         public void Save()
         {
             this.Save<Card>();
         }
 
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Card>();
+        }
+
         public void Reload()
         {
             this.Reload<Card>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Card>();
         }
 
         public void AssociateToCustomer(Customer customer)
@@ -88,10 +103,20 @@ namespace Balanced
 
         public void AssociateToCustomer(string href)
         {
+            AssociateToCustomerAsync(href).GetAwaiter().GetResult();
+        }
+
+        public Task AssociateToCustomerAsync(Customer customer)
+        {
+            return this.AssociateToCustomerAsync(customer.href);
+        }
+
+        public async Task AssociateToCustomerAsync(string href)
+        {
             if (href != null)
             {
                 links.Add("customer", href);
-                this.Save();
+                await this.SaveAsync();
             }
         }
 
@@ -100,17 +125,22 @@ namespace Balanced
             return card_holds.Create(payload);
         }
 
-        public override Debit Debit(Dictionary<string, object> payload)
+        public Task<CardHold> HoldAsync(Dictionary<string, object> payload)
         {
-            return debits.Create(payload);
+            return card_holds.CreateAsync(payload);
         }
 
-        public override Credit Credit(Dictionary<string, object> payload)
+        public override Task<Debit> DebitAsync(Dictionary<string, object> payload)
+        {
+            return debits.CreateAsync(payload);
+        }
+
+        public override Task<Credit> CreditAsync(Dictionary<string, object> payload)
         {
             if (credits == null) {
                 throw new Exceptions.FundingInstrumentNotCreditable();
             }
-            return credits.Create(payload);
+            return credits.CreateAsync(payload);
         }
 
         public class Collection : ResourceCollection<Card>

--- a/Balanced/CardHold.cs
+++ b/Balanced/CardHold.cs
@@ -1,9 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using System.Threading.Tasks;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Balanced
 {
@@ -59,9 +57,19 @@ namespace Balanced
             return Resource.Fetch<CardHold>(href);
         }
 
+        public static Task<CardHold> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<CardHold>(href);
+        }
+
         public void Save()
         {
             this.Save<CardHold>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<CardHold>();
         }
 
         public void Reload()
@@ -69,14 +77,29 @@ namespace Balanced
             this.Reload<CardHold>();
         }
 
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<CardHold>();
+        }
+
         public Debit Capture(Dictionary<string, object> payload)
         {
-            return debits.Create(payload);
+            return CaptureAsync(payload).GetAwaiter().GetResult();
         }
 
         public Debit Capture()
         {
-            return this.Capture(null);
+            return CaptureAsync().GetAwaiter().GetResult();
+        }
+
+        public Task<Debit> CaptureAsync(Dictionary<string, object> payload)
+        {
+            return debits.CreateAsync(payload);
+        }
+
+        public Task<Debit> CaptureAsync()
+        {
+            return this.CaptureAsync(null);
         }
 
         public class Collection : ResourceCollection<CardHold>

--- a/Balanced/Client.cs
+++ b/Balanced/Client.cs
@@ -31,20 +31,18 @@ namespace Balanced
 
     public static class Client
     {
-        public static dynamic processResponse(HttpWebRequest request)
+        public static string processResponse(HttpWebRequest request)
         {
             return processResponseAsync(request).GetAwaiter().GetResult();
         }
 
-        public static async Task<dynamic> processResponseAsync(HttpWebRequest request)
+        public static async Task<string> processResponseAsync(HttpWebRequest request)
         {
             HttpWebResponse exceptionResponse = null;
 
             try
             {
-                var task = request.GetResponseAsync();
-                var response = await task;
-                using (response)
+                using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
                 {
                     using (var stream = new StreamReader(response.GetResponseStream(), Encoding.GetEncoding(1252)))
                     {
@@ -60,7 +58,7 @@ namespace Balanced
             return await HandleExceptionResponse(exceptionResponse);
         }
 
-        private static async Task<dynamic> HandleExceptionResponse(HttpWebResponse exceptionResponse)
+        private static async Task<string> HandleExceptionResponse(HttpWebResponse exceptionResponse)
         {
             string responsePayload = string.Empty;
             using (var stream = new StreamReader(exceptionResponse.GetResponseStream()))
@@ -83,12 +81,12 @@ namespace Balanced
             return responsePayload;
         }
 
-        private static dynamic Op(string path, string method, string payload)
+        private static string Op(string path, string method, string payload)
         {
             return OpAsync(path, method, payload).GetAwaiter().GetResult();
         }
 
-        private static async Task<dynamic> OpAsync(string path, string method, string payload)
+        private static async Task<string> OpAsync(string path, string method, string payload)
         {
             string url = Balanced.API_URL + path;
             var request = (HttpWebRequest)WebRequest.Create(url);
@@ -119,22 +117,22 @@ namespace Balanced
             return await processResponseAsync(request);
         }
 
-        public static dynamic Get<T>(string path)
+        public static T Get<T>(string path)
         {
-            return Get<T>(path, true);
+            return (T)Get<T>(path, true);
         }
 
-        public static dynamic Get<T>(string path, bool deserialize)
+        public static object Get<T>(string path, bool deserialize)
         {
             return GetAsync<T>(path, deserialize).GetAwaiter().GetResult();
         }
 
-        public static dynamic GetAsync<T>(string path)
+        public static async Task<T> GetAsync<T>(string path)
         {
-            return GetAsync<T>(path, true);
+            return (T)await GetAsync<T>(path, true);
         }
 
-        public static async Task<dynamic> GetAsync<T>(string path, bool deserialize)
+        public static async Task<object> GetAsync<T>(string path, bool deserialize)
         {
             var op = await OpAsync(path, "GET", null);
 
@@ -151,7 +149,7 @@ namespace Balanced
             return Deserialize(Op(path, "POST", payload), typeof(T));
         }
 
-        public static async Task<dynamic> PostAsync<T>(string path, string payload)
+        public static async Task<T> PostAsync<T>(string path, string payload)
         {
             return Deserialize(await OpAsync(path, "POST", payload), typeof(T));
         }
@@ -161,7 +159,7 @@ namespace Balanced
             return Deserialize(Op(path, "PUT", payload), typeof(T));
         }
 
-        public static async Task<dynamic> PutAsync<T>(string path, string payload)
+        public static async Task<T> PutAsync<T>(string path, string payload)
         {
             return Deserialize(await OpAsync(path, "PUT", payload), typeof(T));
         }
@@ -301,16 +299,16 @@ namespace Balanced
                     {
                         if (linkHref.Contains("/CC"))
                         {
-                            res = Deserialize(Client.Get<dynamic>(linkHref, false), typeof(Card), resource);
+                            res = Deserialize((string)Client.Get<dynamic>(linkHref, false), typeof(Card), resource);
                         }
                         else if (linkHref.Contains("/BA"))
                         {
-                            res = Deserialize(Client.Get<dynamic>(linkHref, false), typeof(BankAccount), resource);
+                            res = Deserialize((string)Client.Get<dynamic>(linkHref, false), typeof(BankAccount), resource);
                         }
                     }
                     else
                     {
-                        res = Deserialize(Client.Get<dynamic>(linkHref, false), f.PropertyType, resource);
+                        res = Deserialize((string)Client.Get<dynamic>(linkHref, false), f.PropertyType, resource);
                     }
                 }
 

--- a/Balanced/Credit.cs
+++ b/Balanced/Credit.cs
@@ -1,9 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System.Threading.Tasks;
+using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Balanced
 {
@@ -60,9 +57,19 @@ namespace Balanced
             return Resource.Fetch<Credit>(href);
         }
 
+        public static Task<Credit> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Credit>(href);
+        }
+
         public void Save()
         {
             this.Save<Credit>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Credit>();
         }
 
         public void Reload()
@@ -70,14 +77,29 @@ namespace Balanced
             this.Reload<Credit>();
         }
 
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Credit>();
+        }
+
         public Reversal Reverse(Dictionary<string, object> payload)
         {
-            return reversals.Create(payload);
+            return ReverseAsync(payload).GetAwaiter().GetResult();
         }
 
         public Reversal Reverse()
         {
-            return Reverse(null);
+            return ReverseAsync().GetAwaiter().GetResult();
+        }
+
+        public Task<Reversal> ReverseAsync(Dictionary<string, object> payload)
+        {
+            return reversals.CreateAsync(payload);
+        }
+
+        public Task<Reversal> ReverseAsync()
+        {
+            return ReverseAsync(null);
         }
 
         public class Collection : ResourceCollection<Credit>

--- a/Balanced/Customer.cs
+++ b/Balanced/Customer.cs
@@ -84,9 +84,19 @@ namespace Balanced
             return Resource.Fetch<Customer>(href);
         }
 
+        public static Task<Customer> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Customer>(href);
+        }
+
         public void Save()
         {
             this.Save<Customer>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Customer>();
         }
 
         public void Reload()
@@ -94,9 +104,19 @@ namespace Balanced
             this.Reload<Customer>();
         }
 
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Customer>();
+        }
+
         public Order CreateOrder(Dictionary<string, Object> payload)
         {
-            return orders.Create(payload);
+            return CreateOrderAsync(payload).GetAwaiter().GetResult();
+        }
+
+        public Task<Order> CreateOrderAsync(Dictionary<string, Object> payload)
+        {
+            return orders.CreateAsync(payload);
         }
 
         public class Collection : ResourceCollection<Customer>

--- a/Balanced/Debit.cs
+++ b/Balanced/Debit.cs
@@ -63,14 +63,29 @@ namespace Balanced
             return Resource.Fetch<Debit>(href);
         }
 
+        public static Task<Debit> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Debit>(href);
+        }
+
         public void Save()
         {
             this.Save<Debit>();
         }
 
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Debit>();
+        }
+
         public void Reload()
         {
             this.Reload<Debit>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Debit>();
         }
 
         public Refund Refund(Dictionary<string, object> payload)
@@ -81,6 +96,16 @@ namespace Balanced
         public Refund Refund()
         {
             return Refund(null);
+        }
+
+        public Task<Refund> RefundAsync(Dictionary<string, object> payload)
+        {
+            return refunds.CreateAsync(payload);
+        }
+
+        public Task<Refund> RefundAsync()
+        {
+            return RefundAsync(null);
         }
 
         public class Collection : ResourceCollection<Debit>

--- a/Balanced/Dispute.cs
+++ b/Balanced/Dispute.cs
@@ -41,6 +41,11 @@ namespace Balanced
             return Resource.Fetch<Dispute>(href);
         }
 
+        public static Task<Dispute> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Dispute>(href);
+        }
+
         public class Collection : ResourceCollection<Dispute>
         {
             public Collection() : base(resource_href) { }

--- a/Balanced/Event.cs
+++ b/Balanced/Event.cs
@@ -32,6 +32,11 @@ namespace Balanced
             return Resource.Fetch<Event>(href);
         }
 
+        public static Task<Event> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Event>(href);
+        }
+
         public class Collection : ResourceCollection<Event>
         {
             public Collection() : base(resource_href) { }

--- a/Balanced/FundingInstrument.cs
+++ b/Balanced/FundingInstrument.cs
@@ -19,7 +19,17 @@ namespace Balanced
         [ResourceField(serialize = false)]
         public string fingerprint { get; set; }
 
-        public abstract Debit Debit(Dictionary<string, object> payload);
-        public abstract Credit Credit(Dictionary<string, object> payload);
+        public Debit Debit(Dictionary<string, object> payload)
+        {
+            return DebitAsync(payload).GetAwaiter().GetResult();
+        }
+
+        public Credit Credit(Dictionary<string, object> payload)
+        {
+            return CreditAsync(payload).GetAwaiter().GetResult();
+        }
+
+        public abstract Task<Debit> DebitAsync(Dictionary<string, object> payload);
+        public abstract Task<Credit> CreditAsync(Dictionary<string, object> payload);
     }
 }

--- a/Balanced/Marketplace.cs
+++ b/Balanced/Marketplace.cs
@@ -86,14 +86,29 @@ namespace Balanced
             return Resource.Fetch<Marketplace>(href);
         }
 
+        public static Task<Marketplace> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Marketplace>(href);
+        }
+
         public void Save()
         {
             this.Save<Marketplace>();
         }
 
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Marketplace>();
+        }
+
         public void Reload()
         {
             this.Reload<Marketplace>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Marketplace>();
         }
 
         public static ResourceQuery<Marketplace> Query()

--- a/Balanced/Order.cs
+++ b/Balanced/Order.cs
@@ -57,9 +57,19 @@ namespace Balanced
             return Resource.Fetch<Order>(href);
         }
 
+        public static Task<Order> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Order>(href);
+        }
+
         public void Save()
         {
             this.Save<Order>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Order>();
         }
 
         public void Reload()
@@ -67,16 +77,31 @@ namespace Balanced
             this.Reload<Order>();
         }
 
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Order>();
+        }
+
         public Debit DebitFrom(FundingInstrument fi, Dictionary<string, object> options)
         {
+            return DebitFromAsync(fi, options).GetAwaiter().GetResult();
+        }
+
+        public Task<Debit> DebitFromAsync(FundingInstrument fi, Dictionary<string, object> options)
+        {
             options.Add("order", this.href);
-            return fi.Debit(options);
+            return fi.DebitAsync(options);
         }
 
         public Credit CreditTo(BankAccount ba, Dictionary<string, object> options)
         {
+            return CreditToAsync(ba, options).GetAwaiter().GetResult();
+        }
+
+        public Task<Credit> CreditToAsync(BankAccount ba, Dictionary<string, object> options)
+        {
             options.Add("order", this.href);
-            return ba.Credit(options);
+            return ba.CreditAsync(options);
         }
 
         public class Collection : ResourceCollection<Order>

--- a/Balanced/Refund.cs
+++ b/Balanced/Refund.cs
@@ -50,14 +50,29 @@ namespace Balanced
             return Resource.Fetch<Refund>(href);
         }
 
-        public void save()
+        public static Task<Refund> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Refund>(href);
+        }
+
+        public void Save()
         {
             this.Save<Refund>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Refund>();
         }
 
         public void Reload()
         {
             this.Reload<Refund>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Refund>();
         }
 
         public class Collection : ResourceCollection<Refund>

--- a/Balanced/Resource.cs
+++ b/Balanced/Resource.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using System.Collections;
-
 using Newtonsoft.Json;
-using System.Dynamic;
 using System.Reflection;
 
 namespace Balanced
@@ -30,16 +26,20 @@ namespace Balanced
 
         public void Save<T>()
         {
+            SaveAsync<T>().GetAwaiter().GetResult();
+        }
+        public async Task SaveAsync<T>()
+        {
             dynamic res = null;
 
             if (this.href != null)
             {
-                res = Client.Put<T>(this.href, Serialize(this));
+                res = await Client.PutAsync<T>(this.href, Serialize(this));
             }
             else
             {
                 string href = this.GetType().GetProperty("resource_href").GetValue(this).ToString();
-                res = Client.Post<T>(href, Serialize(this));
+                res = await Client.PostAsync<T>(href, Serialize(this));
             }
 
             UpdateResource<T>(res);
@@ -50,14 +50,29 @@ namespace Balanced
             Client.Delete(this.href);
         }
 
+        public Task UnstoreAsync()
+        {
+            return Client.DeleteAsync(this.href);
+        }
+
         public static T Fetch<T>(string href)
         {
             return Client.Get<T>(href);
         }
 
+        public static Task<T> FetchAsync<T>(string href)
+        {
+            return Client.GetAsync<T>(href);
+        }
+
         public void Reload<T>()
         {
-            dynamic res = Client.Get<T>(href);
+            ReloadAsync<T>().GetAwaiter().GetResult();
+        }
+
+        public async Task ReloadAsync<T>()
+        {
+            dynamic res = await Client.GetAsync<T>(href);
             UpdateResource<T>(res);
         }
 

--- a/Balanced/ResourcePage.cs
+++ b/Balanced/ResourcePage.cs
@@ -108,7 +108,7 @@ namespace Balanced
     
         internal void Load()
         {
-            string responsePayload = Client.Get<Dictionary<string, object>>(href, false);
+            string responsePayload = (string)Client.Get<Dictionary<string, object>>(href, false);
             var responseObject = JObject.Parse(responsePayload);
             IList<string> keys = responseObject.Properties().Select(p => p.Name).ToList();
             Dictionary<string, object> meta = null;

--- a/Balanced/ResourcePagination.cs
+++ b/Balanced/ResourcePagination.cs
@@ -71,15 +71,22 @@ namespace Balanced
 
         public T Create()
         {
-            Dictionary<string, object> payload = new Dictionary<string, object>();
-            return Create(payload);
+            return Create(new Dictionary<string, object>());
         }
 
         public T Create(Dictionary<string, object> payload)
         {
-            dynamic resource;
-            resource = Client.Post<T>(GetURI(), Resource.Serialize(payload));
-            return resource;
+            return CreateAsync(payload).GetAwaiter().GetResult();
+        }
+
+        public Task<T> CreateAsync()
+        {
+            return CreateAsync(new Dictionary<string, object>());
+        }
+
+        public async Task<T> CreateAsync(Dictionary<string, object> payload)
+        {
+            return await Client.PostAsync<T>(GetURI(), Resource.Serialize(payload));
         }
 
         public class ResourceIterator : IEnumerator

--- a/Balanced/Reversal.cs
+++ b/Balanced/Reversal.cs
@@ -51,14 +51,29 @@ namespace Balanced
             return Resource.Fetch<Reversal>(href);
         }
 
+        public static Task<Reversal> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Reversal>(href);
+        }
+
         public void Save()
         {
             this.Save<Reversal>();
         }
 
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Reversal>();
+        }
+
         public void Reload()
         {
             this.Reload<Reversal>();
+        }
+
+        public Task ReloadAsync()
+        {
+            return this.ReloadAsync<Reversal>();
         }
 
         public class Collection : ResourceCollection<Reversal>

--- a/Balanced/Settlement.cs
+++ b/Balanced/Settlement.cs
@@ -52,9 +52,19 @@ namespace Balanced
             return Resource.Fetch<Settlement>(href);
         }
 
+        public static Task<Settlement> FetchAsync(string href)
+        {
+            return Resource.FetchAsync<Settlement>(href);
+        }
+
         public void Save()
         {
             this.Save<Settlement>();
+        }
+
+        public Task SaveAsync()
+        {
+            return this.SaveAsync<Settlement>();
         }
 
         public class Collection : ResourceCollection<Settlement>

--- a/BalancedTests/DebitTest.cs
+++ b/BalancedTests/DebitTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Balanced;
 using System.Collections.Generic;
@@ -167,7 +168,7 @@ namespace BalancedTests
             );
 
             var request = new Mock<HttpWebRequest>();
-            request.Setup(c => c.GetResponse()).Returns(response.Object);
+            request.Setup(c => c.GetResponseAsync()).Returns(() => Task.FromResult((WebResponse)response.Object));
 
             var factory = new Mock<IHttpWebRequestFactory>();
             factory.Setup(c => c.Create(It.IsAny<string>()))


### PR DESCRIPTION
Using tasks allow for thread resources to be reused while IO calls are made. This allows better security on ASP.NET sites since it is more difficult to use up all the available request threads when under heavy load (i.e. lots of customers or a DOS attack). I've left all the original public methods to preserve back-compat and called into the Async methods from the blocking methods when appropriate by using .GetAwaiter().GetResult() in order to preserve any exceptions that might be thrown. Verified by running all unit tests.
